### PR TITLE
Feature/per page layouts

### DIFF
--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -1,35 +1,12 @@
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
 import Header from "./Header";
-import ProjectsPageLayout from "./ProjectsPageLayout";
 
 function Layout({ children }) {
-  const router = useRouter();
-  const [isProjectsPage, setIsProjectsPage] = useState(false);
-
-  useEffect(() => {
-    if (checkIsProjectsPage(router.route.split("/")[1])) {
-      setIsProjectsPage(true);
-    } else {
-      setIsProjectsPage(false);
-    }
-  }, [router.route]);
-
-  const checkIsProjectsPage = (routeFirstElement) =>
-    routeFirstElement === "projects";
-
   return (
     <section className="bg-bgGrey min-h-screen">
       <div className="w-full max-w-screen-xl mx-auto">
         <Header />
         <div className="relative mx-6">
-          {isProjectsPage ? (
-            <main>
-              <ProjectsPageLayout>{children}</ProjectsPageLayout>
-            </main>
-          ) : (
-            <main>{children}</main>
-          )}
+          <main>{children}</main>
         </div>
       </div>
     </section>

--- a/components/layout/ProjectsPageLayout.js
+++ b/components/layout/ProjectsPageLayout.js
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { findMember } from "../../redux/slices/memberSlice";
+import Layout from "./Layout";
 
 function ProjectsPageLayout({ children }) {
   const member = {};
@@ -24,7 +25,7 @@ function ProjectsPageLayout({ children }) {
   }, [dispatch]);
 
   return (
-    <>
+    <Layout>
       <div
         role="list"
         className="grid grid-cols-1 gap-y-3 md:gap-x-3 md:grid-cols-5"
@@ -35,7 +36,7 @@ function ProjectsPageLayout({ children }) {
         {/* Main column */}
         {children}
       </div>
-    </>
+    </Layout>
   );
 }
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,15 +2,12 @@ import "../styles/globals.css";
 import "tailwindcss/tailwind.css";
 import { store } from "../redux/store";
 import { Provider } from "react-redux";
-import Layout from "../components/layout/Layout";
 
 function MyApp({ Component, pageProps }) {
+  // Use the layout defined at the page level, if available
+  const getLayout = Component.getLayout || ((page) => page);
   return (
-    <Provider store={store}>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
-    </Provider>
+    <Provider store={store}>{getLayout(<Component {...pageProps} />)}</Provider>
   );
 }
 

--- a/pages/projects/[projectId].js
+++ b/pages/projects/[projectId].js
@@ -8,6 +8,7 @@ import Image from "next/image";
 import { useDispatch, useSelector } from "react-redux";
 import { findProject } from "../../redux/slices/projectSlice";
 import { useRouter } from "next/router";
+import ProjectsPageLayout from "../../components/layout/ProjectsPageLayout";
 
 const roles = [
   {
@@ -96,7 +97,7 @@ const roles = [
   },
 ];
 
-export default function ProjectDetail() {
+function ProjectDetail() {
   const router = useRouter();
   const project = useSelector((state) => state.projectInspect);
   const dispatch = useDispatch();
@@ -228,3 +229,9 @@ export default function ProjectDetail() {
     </Fragment>
   );
 }
+
+ProjectDetail.getLayout = function getLayout(page) {
+  return <ProjectsPageLayout>{page}</ProjectsPageLayout>;
+};
+
+export default ProjectDetail;

--- a/pages/projects/index.js
+++ b/pages/projects/index.js
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useDispatch, useSelector } from "react-redux";
 import { findProjects } from "../../redux/slices/projectsSlice";
+import ProjectsPageLayout from "../../components/layout/ProjectsPageLayout";
 
 const mockData = {
   howToApply: {
@@ -51,7 +52,7 @@ const tabs = [
   },
 ];
 
-export default function FavouriteProjects() {
+function FavouriteProjects() {
   const [currentTab, setCurrentTab] = useState(0);
 
   tabs[0].projects = useSelector((state) => {
@@ -227,3 +228,9 @@ export default function FavouriteProjects() {
     </Fragment>
   );
 }
+
+FavouriteProjects.getLayout = function getLayout(page) {
+  return <ProjectsPageLayout>{page}</ProjectsPageLayout>;
+};
+
+export default FavouriteProjects;


### PR DESCRIPTION
This PR implements the per-page layout pattern suggested in the NextJS docs (see per page layouts section)

https://nextjs.org/docs/basic-features/layouts

This should give us a cleaner way to define and render a specific layout (including fetching page/route specific data) for each route/page as needed.