### PR TITLE
prevent render before team data available

### DIFF
--- a/pages/champion-dashboard/[_id].js
+++ b/pages/champion-dashboard/[_id].js
@@ -29,13 +29,13 @@ const Project = () => {
   }, [dispatch, _id]);
 
   const {
-    projectInspect: { isDataAvailable, team },
+    projectInspect: { team },
   } = useSelector((state) => state);
 
   return (
     <>
       <main className="col-span-3">
-        {isDataAvailable && (
+        {team && (
           <section className="rounded-2xl overflow-hidden bg-[#8dc2204c]">
             <div className="grid grid-cols-2">
               <button


### PR DESCRIPTION
fixed error occurring when visiting champion dashboard immediately after creating a new project